### PR TITLE
Change Metka column initialiation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ end
 
 ```ruby
 class Song < ActiveRecord::Base
-  include Metka::Model(column: 'tags')
-  include Metka::Model(column: 'genres')
+  include Metka::Model
+
+  has_metka do
+    column :tags
+    column :genres
+  end
 end
 
 @song = Song.new(title: 'Migrate tags in Rails to PostgreSQL')
@@ -121,7 +125,7 @@ Song.without_any_genres('')
 By default, a comma is used as a delimiter to create tags from a string.
 You can make your own custom separator:
 ```ruby
-Metka.config.delimiter = [',', ' ', '\|']
+Metka.config.delimiter = [',', ' ', '|']
 parsed_data = Metka::GenericParser.instance.call('cool, data|I have')
 parsed_data.to_a
 =>['cool', 'data', 'I', 'have']
@@ -139,8 +143,12 @@ By default we use [generic_parser](lib/metka/generic_parser.rb "generic_parser")
 If you want use your custom parser you can do:
 ```ruby
 class Song < ActiveRecord::Base
-  include Metka::Model(column: 'tags', parser: Your::Custom::Parser.instance)
-  include Metka::Model(column: 'genres')
+  include Metka::Model
+
+  has_metka do
+    column :tags, parser: Your::Custom::Parser.instance
+    column :genres
+  end
 end
 ```
 Custom parser must be a singleton class that has a `.call` method that accepts the tag string

--- a/lib/metka/generic_parser.rb
+++ b/lib/metka/generic_parser.rb
@@ -37,8 +37,9 @@ module Metka
     end
 
     def joined_delimiter
-      delimeter = Metka.config.delimiter
-      delimeter.is_a?(Array) ? delimeter.join('|') : delimeter
+      [Metka.config.delimiter].flatten
+        .map { |delimeter| Regexp.escape(delimeter) }
+        .join('|')
     end
 
     def single_quote_pattern

--- a/lib/metka/model.rb
+++ b/lib/metka/model.rb
@@ -1,46 +1,16 @@
 # frozen_string_literal: true
 
-module Metka
-  def self.Model(column:, **options)
-    Metka::Model.new(column: column, **options)
-  end
+require_relative 'model/integration'
 
-  class Model < Module
-    def initialize(column: , **options)
-      @column = column
-      @options = options
+module Metka
+  module Model
+    def self.included(base)
+      base.extend ClassMethods
     end
 
-    def included(base)
-      column = @column
-      parser = ->(tags) {
-        @options[:parser] ? @options[:parser].call(tags) : Metka.config.parser.instance.call(tags)
-      }
-
-      search_by_tags = ->(model, tags, column, **options) {
-        parsed_tag_list = parser.call(tags)
-        if options[:without].present?
-          model.where.not(::Metka::QueryBuilder.new.call(model, column, parsed_tag_list, options))
-        else
-          return model.none if parsed_tag_list.empty?
-          model.where(::Metka::QueryBuilder.new.call(model, column, parsed_tag_list, options))
-        end
-      }
-
-      base.class_eval do
-        scope "with_all_#{column}", ->(tags) { search_by_tags.call(self, tags, column) }
-        scope "with_any_#{column}", ->(tags) { search_by_tags.call(self, tags, column, { any: true }) }
-        scope "without_all_#{column}", ->(tags) { search_by_tags.call(self, tags, column, { exclude_all: true, without: true }) }
-        scope "without_any_#{column}", ->(tags) { search_by_tags.call(self, tags, column, { exclude_any: true, without: true }) }
-      end
-
-      base.define_method(column.singularize + '_list=') do |v|
-        self.write_attribute(column, parser.call(v).to_a)
-        self.write_attribute(column, nil) if self.send(column).empty?
-      end
-
-      base.define_method(column.singularize + '_list') do
-        parser.call(self.send(column))
+    module ClassMethods
+      def has_metka(&block)
+        Metka::Model::Integration.new(self).integrate!(&block)
       end
     end
   end

--- a/lib/metka/model/integration.rb
+++ b/lib/metka/model/integration.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Metka
+  module Model
+    class Integration
+      def initialize(owner_class)
+        @owner_class = owner_class
+      end
+
+      def integrate!(&block)
+        instance_eval(&block) if block_given?
+      end
+
+      def column(column_name, **options)
+        parser = options[:parser] || Metka.config.parser.instance
+
+        add_scopes_to_owner!(column_name, search_by_tags_method_for(column_name, parser))
+        add_list_methods_to_owner!(column_name, parser)
+      end
+
+      private
+
+      def search_by_tags_method_for(column_name, parser)
+        ->(model, tags, **options) {
+          parsed_tag_list = parser.call(tags)
+
+          if options[:without].present?
+            model.where.not(::Metka::QueryBuilder.new.call(model, column_name, parsed_tag_list, options))
+          else
+            return model.none if parsed_tag_list.empty?
+            model.where(::Metka::QueryBuilder.new.call(model, column_name, parsed_tag_list, options))
+          end
+        }
+      end
+
+      def add_scopes_to_owner!(column_name, search_method)
+        @owner_class.class_eval do
+          scope "with_all_#{column_name}",    ->(tags) { search_method.call(self, tags) }
+          scope "with_any_#{column_name}",    ->(tags) { search_method.call(self, tags, { any: true }) }
+          scope "without_all_#{column_name}", ->(tags) { search_method.call(self, tags, { exclude_all: true, without: true }) }
+          scope "without_any_#{column_name}", ->(tags) { search_method.call(self, tags, { exclude_any: true, without: true }) }
+        end
+      end
+
+      def add_list_methods_to_owner!(column_name, parser)
+        @owner_class.define_method(:"#{column_name.to_s.singularize}_list=") do |v|
+          self.write_attribute(column_name, parser.call(v).to_a)
+          self.write_attribute(column_name, nil) if self.send(column_name).empty?
+        end
+
+        @owner_class.define_method(:"#{column_name.to_s.singularize}_list") do
+          parser.call(self.send(column_name))
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/materialized_view_post.rb
+++ b/spec/dummy/app/models/materialized_view_post.rb
@@ -3,7 +3,9 @@
 # This class use strategies materialized view
 # You can find out more here: lib/generators/metka/strategies/materialized_view/materialized_view_generator.rb
 class MaterializedViewPost < ActiveRecord::Base
-  include Metka::Model(column: 'tags')
+  include Metka::Model
+
+  has_metka { column :tags }
 
   belongs_to :user
 end

--- a/spec/dummy/app/models/view_post.rb
+++ b/spec/dummy/app/models/view_post.rb
@@ -3,8 +3,12 @@
 # This class use strategies view
 # You can find out more here: lib/generators/metka/strategies/view/view_generator.rb
 class ViewPost < ActiveRecord::Base
-  include Metka::Model(column: 'tags')
-  include Metka::Model(column: 'materials')
+  include Metka::Model
+
+  has_metka do
+    column :tags
+    column :materials, parser: CustomParser.instance
+  end
 
   belongs_to :user
 end

--- a/spec/dummy/app/services/custom_parser.rb
+++ b/spec/dummy/app/services/custom_parser.rb
@@ -1,0 +1,9 @@
+class CustomParser < Metka::GenericParser
+  DELIMITER = '\|'.freeze
+
+  private
+
+  def joined_delimiter
+    DELIMITER
+  end
+end

--- a/spec/metka/generic_parser_spec.rb
+++ b/spec/metka/generic_parser_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Metka::GenericParser do
     end
 
     it 'should separate tags by delimiters' do
-      Metka.config.delimiter = [',', ' ', '\|']
+      Metka.config.delimiter = [',', ' ', '|']
       parsed_data = subject.call('cool, data|I have')
       expect(parsed_data.to_a).to eq(%w[cool data I have])
     end
@@ -37,7 +37,7 @@ RSpec.describe Metka::GenericParser do
     end
 
     it 'should escape single quote' do
-      Metka.config.delimiter = [',', ' ', '\|']
+      Metka.config.delimiter = [',', ' ', '|']
       parsed_data = subject.call("'I have'|cool, data")
 
       expect(parsed_data.to_a).to eq(['I have', 'cool', 'data'])

--- a/spec/metka/model_spec.rb
+++ b/spec/metka/model_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Metka::Model, :db do
   let!(:tag_list) { 'ruby, rails, crystal' }
-  let!(:material_list) { 'steel, wood, rock' }
+  let!(:material_list) { 'steel | wood | rock' }
   let!(:user) { User.create(name: Faker::Name.name) }
   let!(:view_post) { ViewPost.new(user_id: user.id)}
   let!(:view_post_two) { ViewPost.new(user_id: user.id)}
@@ -98,8 +98,8 @@ RSpec.describe Metka::Model, :db do
 
       it 'should be able to find by material' do
         expect(ViewPost.with_all_materials(material_list)).to be_present
-        expect(ViewPost.with_all_materials(material_list.split(', ').first)).to be_present
-        expect(ViewPost.with_all_materials(material_list.split(', ').last)).to be_present
+        expect(ViewPost.with_all_materials(material_list.split(' | ').first)).to be_present
+        expect(ViewPost.with_all_materials(material_list.split(' | ').last)).to be_present
         expect(ViewPost.with_all_materials(material_list).first).to eq(view_post)
       end
 
@@ -108,13 +108,13 @@ RSpec.describe Metka::Model, :db do
       end
 
       it 'should return an empty scope for unused materials' do
-        finding_materials = [material_list.split(', ').first, 'PHP']
+        finding_materials = [material_list.split(' | ').first, 'PHP']
         expect(ViewPost.with_all_materials(finding_materials)).to be_empty
       end
     end
 
     describe '.with_any_materials' do
-      let(:new_material_list) { material_list + 'iron'}
+      let(:new_material_list) { material_list + ' | iron'}
 
       it 'should respond to .with_any_materials' do
         expect(ViewPost).to respond_to(:with_any_materials)
@@ -122,12 +122,12 @@ RSpec.describe Metka::Model, :db do
 
       it 'should be able to find by material' do
         expect(ViewPost.with_any_materials(new_material_list)).to be_present
-        expect(ViewPost.with_any_materials(new_material_list.split(', ').first)).to be_present
+        expect(ViewPost.with_any_materials(new_material_list.split(' | ').first)).to be_present
         expect(ViewPost.with_any_materials(new_material_list).first).to eq(view_post)
       end
 
       it 'should return an empty scope for unused tags' do
-        expect(ViewPost.with_any_materials(new_material_list.split(', ').last)).to be_empty
+        expect(ViewPost.with_any_materials(new_material_list.split(' | ').last)).to be_empty
       end
     end
   end


### PR DESCRIPTION
### Changes

- updated the Metka column initialization process in accordance with https://github.com/jetrockets/metka/issues/1
- added Regexp escape for delimiters, so pipe symbol (`|`) isn't required to be escaped manually anymore
- updated `Metka::Model` specs to check custom parser with custom delimiter provision