### PR TITLE
Add escape parser delimiters for regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Song.without_any_genres('')
 By default, a comma is used as a delimiter to create tags from a string.
 You can make your own custom separator:
 ```ruby
-Metka.config.delimiter = [',', ' ', '\|']
+Metka.config.delimiter = [',', ' ', '|']
 parsed_data = Metka::GenericParser.instance.call('cool, data|I have')
 parsed_data.to_a
 =>['cool', 'data', 'I', 'have']

--- a/lib/metka/generic_parser.rb
+++ b/lib/metka/generic_parser.rb
@@ -37,8 +37,9 @@ module Metka
     end
 
     def joined_delimiter
-      delimeter = Metka.config.delimiter
-      delimeter.is_a?(Array) ? delimeter.join('|') : delimeter
+      [Metka.config.delimiter].flatten
+        .map { |delimeter| Regexp.escape(delimeter) }
+        .join('|')
     end
 
     def single_quote_pattern

--- a/spec/dummy/app/models/view_post.rb
+++ b/spec/dummy/app/models/view_post.rb
@@ -4,7 +4,7 @@
 # You can find out more here: lib/generators/metka/strategies/view/view_generator.rb
 class ViewPost < ActiveRecord::Base
   include Metka::Model(column: 'tags')
-  include Metka::Model(column: 'materials')
+  include Metka::Model(column: 'materials', parser: CustomParser.instance)
 
   belongs_to :user
 end

--- a/spec/dummy/app/services/custom_parser.rb
+++ b/spec/dummy/app/services/custom_parser.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CustomParser < Metka::GenericParser
+  DELIMITER = '\|'.freeze
+
+  private
+
+  def joined_delimiter
+    DELIMITER
+  end
+end

--- a/spec/metka/generic_parser_spec.rb
+++ b/spec/metka/generic_parser_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Metka::GenericParser do
     end
 
     it 'should separate tags by delimiters' do
-      Metka.config.delimiter = [',', ' ', '\|']
+      Metka.config.delimiter = [',', ' ', '|']
       parsed_data = subject.call('cool, data|I have')
       expect(parsed_data.to_a).to eq(%w[cool data I have])
     end
@@ -37,7 +37,7 @@ RSpec.describe Metka::GenericParser do
     end
 
     it 'should escape single quote' do
-      Metka.config.delimiter = [',', ' ', '\|']
+      Metka.config.delimiter = [',', ' ', '|']
       parsed_data = subject.call("'I have'|cool, data")
 
       expect(parsed_data.to_a).to eq(['I have', 'cool', 'data'])

--- a/spec/metka/model_spec.rb
+++ b/spec/metka/model_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Metka::Model, :db do
   let!(:tag_list) { 'ruby, rails, crystal' }
-  let!(:material_list) { 'steel, wood, rock' }
+  let!(:material_list) { 'steel | wood | rock' }
   let!(:user) { User.create(name: Faker::Name.name) }
   let!(:view_post) { ViewPost.new(user_id: user.id)}
   let!(:view_post_two) { ViewPost.new(user_id: user.id)}
@@ -98,8 +98,8 @@ RSpec.describe Metka::Model, :db do
 
       it 'should be able to find by material' do
         expect(ViewPost.with_all_materials(material_list)).to be_present
-        expect(ViewPost.with_all_materials(material_list.split(', ').first)).to be_present
-        expect(ViewPost.with_all_materials(material_list.split(', ').last)).to be_present
+        expect(ViewPost.with_all_materials(material_list.split(' | ').first)).to be_present
+        expect(ViewPost.with_all_materials(material_list.split(' | ').last)).to be_present
         expect(ViewPost.with_all_materials(material_list).first).to eq(view_post)
       end
 
@@ -108,13 +108,13 @@ RSpec.describe Metka::Model, :db do
       end
 
       it 'should return an empty scope for unused materials' do
-        finding_materials = [material_list.split(', ').first, 'PHP']
+        finding_materials = [material_list.split(' | ').first, 'PHP']
         expect(ViewPost.with_all_materials(finding_materials)).to be_empty
       end
     end
 
     describe '.with_any_materials' do
-      let(:new_material_list) { material_list + 'iron'}
+      let(:new_material_list) { material_list + ' | iron'}
 
       it 'should respond to .with_any_materials' do
         expect(ViewPost).to respond_to(:with_any_materials)
@@ -122,12 +122,12 @@ RSpec.describe Metka::Model, :db do
 
       it 'should be able to find by material' do
         expect(ViewPost.with_any_materials(new_material_list)).to be_present
-        expect(ViewPost.with_any_materials(new_material_list.split(', ').first)).to be_present
+        expect(ViewPost.with_any_materials(new_material_list.split(' | ').first)).to be_present
         expect(ViewPost.with_any_materials(new_material_list).first).to eq(view_post)
       end
 
       it 'should return an empty scope for unused tags' do
-        expect(ViewPost.with_any_materials(new_material_list.split(', ').last)).to be_empty
+        expect(ViewPost.with_any_materials(new_material_list.split(' | ').last)).to be_empty
       end
     end
   end


### PR DESCRIPTION
### Changes

- Delimiters are now escaped within GenericParser, so they couldn't mess with resulting regexp
- Added some test cases to check custom parser option