### PR TITLE
Updated README - Added GIN indexes to example of migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /.bundle/
 /.yardoc
 /_yardoc/

--- a/.rubocop-md.yml
+++ b/.rubocop-md.yml
@@ -15,3 +15,6 @@ Lint/Void:
 Lint/DuplicateMethods:
   Exclude:
     - '**/*.md'
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ class CreateSongs < ActiveRecord::Migration[5.0]
   def change
     create_table :songs do |t|
       t.string :title
-      t.string :tags, array: true
-      t.string :genres, array: true
+      t.string :tags, array: true, default: [], index: { using: :gin }
+      t.string :genres, array: true, default: [], index: { using: :gin }
       t.timestamps
     end
   end


### PR DESCRIPTION
In PostgreSQL, for columns with the Array type, we should to use the GIN index for improve searching performance. 
I think, that we should to present it in example of migration, because the new developers can don't know about this ability.